### PR TITLE
Add payment attribute transformer

### DIFF
--- a/ShyimAttributeTransformer.php
+++ b/ShyimAttributeTransformer.php
@@ -18,6 +18,7 @@ class ShyimAttributeTransformer extends Plugin
     const TYPE_PROPERTY_VALUE2 = 'ProductSearch_Facet_Value';
     const TYPE_FORMS = 'Enlight_Controller_Action_PostDispatch_Frontend_Forms';
     const TYPE_STATIC = 'Enlight_Controller_Action_PostDispatch_Frontend_Custom';
+    const TYPE_PAYMENT = 'Legacy_Struct_Converter_Convert_Payment';
 
     const TABLE_MAPPING = [
         self::TYPE_LIST_PRODUCT => 's_articles_attributes',
@@ -29,7 +30,8 @@ class ShyimAttributeTransformer extends Plugin
         self::TYPE_PROPERTY_VALUE2 => 's_filter_values_attributes',
         self::TYPE_FORMS => 's_cms_support_attributes',
         self::TYPE_STATIC => 's_cms_static_attributes',
-        self::TYPE_MANUFACTURER => 's_articles_supplier_attributes'
+        self::TYPE_MANUFACTURER => 's_articles_supplier_attributes',
+        self::TYPE_PAYMENT => 's_core_paymentmeans_attributes',
     ];
 
     public function build(ContainerBuilder $container)

--- a/Subscriber/LegacyStructConverter.php
+++ b/Subscriber/LegacyStructConverter.php
@@ -33,6 +33,7 @@ class LegacyStructConverter implements SubscriberInterface
             'Legacy_Struct_Converter_Convert_Property_Set' => 'legacyStructConverter',
             'Legacy_Struct_Converter_Convert_Configurator_Option' => 'legacyStructConverter',
             'Legacy_Struct_Converter_Convert_Property_Option' => 'legacyStructConverter',
+            'Legacy_Struct_Converter_Convert_Payment' => 'legacyStructConverter',
         ];
     }
 


### PR DESCRIPTION
Support also payment. e.g. for payment logo without in inline description.

I don't know about trailing colons (inconsistent in 2 arrays). I prefer them because less changes, better git blame.

PS: I found no Legacy_Struct_Converter_Convert for Shipping/Dispatch/Premium - any hint or non existing?