### PR TITLE
Fixes issue #8: Do not handle requests to the error controller.

### DIFF
--- a/Subscriber/TemplateSubscriber.php
+++ b/Subscriber/TemplateSubscriber.php
@@ -88,7 +88,7 @@ class TemplateSubscriber implements SubscriberInterface
      */
     public function transformGlobals(Enlight_Controller_ActionEventArgs $eventArgs)
     {
-        if ($eventArgs->getSubject()->Request()->getModuleName() !== 'frontend') {
+        if ($eventArgs->getSubject()->Request()->getModuleName() !== 'frontend' || $eventArgs->getSubject()->Request()->getControllerName() === 'error') {
             return;
         }
 


### PR DESCRIPTION
Issue #8 contains two problems:

1. What Michael did causes a smarty error when compiling the theme. That will trigger a Error Controller.
2. The Error Controller will trigger the Enlight_Controller_Action_PostDispatch Event again and the Plugin will iterate a second time over all the attributes already converted. 